### PR TITLE
feat: add optional ext-applet-external-monitor-brightness

### DIFF
--- a/pkgs/cosmic-ext-applet-external-monitor-brightness/default.nix
+++ b/pkgs/cosmic-ext-applet-external-monitor-brightness/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  libcosmicAppHook,
+  just,
+  pkg-config,
+  udev,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cosmic-ext-applet-external-monitor-brightness";
+  version = "0.1.0-unstable-2025-08-05";
+
+  src = fetchFromGitHub {
+    owner = "cosmic-utils";
+    repo = "cosmic-ext-applet-external-monitor-brightness";
+    rev = "23104965bd9ab1988b040a60f3f1e5d64038e7ce";
+    hash = "sha256-+Hu9bLEbue9bXaGfKa3InhdFI6qsBxccyQY8qzBYFPk=";
+  };
+
+  cargoHash = "sha256-ou7iukl1pHMfcJNemwLdZYYxugbJJQ53XpCYowUTj90=";
+
+  nativeBuildInputs = [
+    just
+    libcosmicAppHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    udev
+  ];
+
+  dontUseJustBuild = true;
+  dontUseJustCheck = true;
+
+  justFlags = [
+    "--set"
+    "rootdir"
+    (placeholder "out")
+    "--set"
+    "prefix"
+    "\"\""
+    "--set"
+    "bin-src"
+    "target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/cosmic-ext-applet-external-monitor-brightness"
+  ];
+
+  meta = {
+    homepage = "https://github.com/cosmic-utils/cosmic-ext-applet-external-monitor-brightness";
+    description = "Change brightness of external monitors via DDC/CI protocol. You can also quickly toggle system dark mode.";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -4,6 +4,7 @@ inputs: final: prev: {
   cosmic-bg = prev.callPackage ./cosmic-bg { };
   cosmic-comp = prev.callPackage ./cosmic-comp { };
   cosmic-ext-applet-clipboard-manager = prev.callPackage ./cosmic-ext-applet-clipboard-manager { };
+  cosmic-ext-applet-external-monitor-brightness = prev.callPackage ./cosmic-ext-applet-external-monitor-brightness { };
   cosmic-edit = prev.callPackage ./cosmic-edit { };
   cosmic-ext-calculator = prev.callPackage ./cosmic-ext-calculator { };
   cosmic-ext-ctl = prev.callPackage ./cosmic-ext-ctl { };


### PR DESCRIPTION
I recently switch to this flake (thanks, it works flawlessly), and I use [`ext-applet-external-monitor-brightness`](https://github.com/cosmic-utils/cosmic-ext-applet-external-monitor-brightness) in my workflow.

Even if it's not updated as frequently as other parts of COSMIC, it's not (yet) in nixpkgs, so I wanted to add it to this flake.
It's my first time writing a package flake, I tried to mimic `cosmic-ext-applet-clipboard-manager`: feel free to modify anything needed!